### PR TITLE
Mimic json/text/buffer method API from micro

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const controlAccess = require('control-access');
 
-module.exports = opts => fn => (req, res) => {
-	controlAccess(opts)(req, res);
-	return fn(req, res);
+module.exports = (req, res, opts) => {
+	return controlAccess(opts)(req, res);
 };

--- a/readme.md
+++ b/readme.md
@@ -28,17 +28,23 @@ module.exports = async (req, res) => {
 
 ### microAccess(req, res, [options])
 
+#### req
+
+Type: `http.IncomingMessage`
+
+Incoming HTTP request.
+
+#### res
+
+Type: `http.ServerResponse`
+
+Response object.
+
 #### options
 
 Type: `Object`
 
 Same as [`control-access`](https://github.com/kevva/control-access#options).
-
-#### handler
-
-Type: `Function`
-
-The request handler to wrap.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,8 @@ $ npm install micro-access
 const {json, send} = require('micro');
 const microAccess = require('micro-access');
 
-module.exports = microAccess()(async (req, res) => {
+module.exports = async (req, res) => {
+	microAccess(req, res);
 	const body = await json(req);
 	send(res, 200, body);
 });
@@ -25,7 +26,7 @@ module.exports = microAccess()(async (req, res) => {
 
 ## API
 
-### microAccess([options])(handler)
+### microAccess(req, res, [options])
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -2,20 +2,23 @@ import {serial as test} from 'ava';
 import got from 'got';
 import micro from 'micro';
 import testListen from 'test-listen';
-import m from '.';
+import access from '.';
 
 const macro = async (t, {header, opts}, expected) => {
-	const access = m(opts);
-	const url = await testListen(micro(access));
+	const url = await testListen(micro((req, res) => {
+		access(req, res, opts);
+		return {};
+	}));
 	t.is((await got(url, {json: true})).headers[header], expected);
 };
 
 const envMacro = async (t, {env, header}, expected) => {
 	const ENV = process.env[env.key];
 	process.env[env.key] = env.value;
-	const access = m();
-	const handler = () => ({});
-	const url = await testListen(micro(access(handler)));
+	const url = await testListen(micro((req, res) => {
+		access(req, res);
+		return {};
+	}));
 	t.is((await got(url, {json: true})).headers[header], expected);
 	process.env[env.key] = ENV;
 };

--- a/test.js
+++ b/test.js
@@ -6,8 +6,7 @@ import m from '.';
 
 const macro = async (t, {header, opts}, expected) => {
 	const access = m(opts);
-	const handler = () => ({});
-	const url = await testListen(micro(access(handler)));
+	const url = await testListen(micro(access));
 	t.is((await got(url, {json: true})).headers[header], expected);
 };
 

--- a/test.js
+++ b/test.js
@@ -2,11 +2,11 @@ import {serial as test} from 'ava';
 import got from 'got';
 import micro from 'micro';
 import testListen from 'test-listen';
-import access from '.';
+import m from '.';
 
 const macro = async (t, {header, opts}, expected) => {
 	const url = await testListen(micro((req, res) => {
-		access(req, res, opts);
+		m(req, res, opts);
 		return {};
 	}));
 	t.is((await got(url, {json: true})).headers[header], expected);
@@ -16,7 +16,7 @@ const envMacro = async (t, {env, header}, expected) => {
 	const ENV = process.env[env.key];
 	process.env[env.key] = env.value;
 	const url = await testListen(micro((req, res) => {
-		access(req, res);
+		m(req, res);
 		return {};
 	}));
 	t.is((await got(url, {json: true})).headers[header], expected);


### PR DESCRIPTION
Just a suggestion about interface.

I would advocate to mimic `json` interface from micro, which takes `req` objects as arguments. This allows to write more complex logic around such functions (like wrap them in `if` or `try...catch`).